### PR TITLE
[codex] Improve root README for clearer onboarding and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,51 @@
 # Perplexity Spaces Prompt Collections
 
-This repository contains modular system prompts for **Perplexity Spaces**. Each directory corresponds to a standalone assistant or workflow.
+Reusable system prompts for Perplexity Spaces, organized as one folder per assistant.
 
-## Features
+## Quick Start
 
-- Rapid prototyping of prompt-based assistants
-- Reusable configurations for rewriting, generating, or templating prompts
+### Prerequisites
+- A Perplexity account with access to Spaces
+- Git (only needed if you want to clone/edit this repo)
 
-### Available Spaces
+### Clone
+```bash
+git clone https://github.com/akilesh/perplexity-spaces-prompts.git
+cd perplexity-spaces-prompts
+```
 
-- `PromptTacular/` – precise prompt rewriting, generation, and templating for LLM app developers.
+### Use a Space Prompt
+1. Open a folder (for example `PromptTacular/`).
+2. Copy the contents of `system_prompt.md`.
+3. Paste it into your Perplexity Space system prompt.
+
+## Core Capabilities
+- Curated, ready-to-use system prompts for specific assistant workflows
+- Folder-based structure that keeps each Space isolated and easy to version
+- Clear per-space documentation (`README.md`) alongside each prompt
+
+## Configuration
+This repository has no required environment variables or runtime setup.
+
+## Usage Example
+```text
+Use PromptTacular to rewrite, generate, or template prompts for LLM applications.
+```
+
+Current space:
+- `PromptTacular/`: high-precision prompt rewriting, prompt generation, and developer-oriented prompt templates
+
+## Contributing
+```bash
+git checkout -b codex/<short-change-name>
+# edit prompt files and README content
+git commit -am "<clear change summary>"
+```
+
+Contribution guidelines:
+- Keep prompts explicit, testable, and scoped to one assistant goal.
+- Update the relevant per-space `README.md` when behavior changes.
+- Keep examples concise and directly runnable in chat products.
+
+## License
+MIT


### PR DESCRIPTION
## Summary
The root README was too brief to help a first-time contributor quickly understand what this repository is, how to use the prompt files, and how to contribute safely. This PR rewrites the root documentation into a practical, small-project README with an actionable quick-start path.

## User Impact
Before this change, a new reader could see that prompt collections existed, but had no clear runbook for using them in Perplexity Spaces or contributing updates. That created onboarding friction and inconsistent contribution patterns.

## Root Cause
The top-level documentation had only a short feature list and a single directory mention. It did not include setup prerequisites, a concrete usage flow, configuration expectations, or contribution guidance.

## Fix
The README now includes:
- a concise project value proposition
- quick start prerequisites, clone commands, and step-by-step usage for `system_prompt.md`
- core capabilities that reflect the repo structure
- explicit note that no runtime/env configuration is required
- a usage example and current space listing
- practical contribution commands and rules
- license section aligned to `LICENSE`

## Validation
- Verified Markdown renders correctly in GitHub-style structure locally
- Confirmed commands are copy-paste ready
- Confirmed README content maps to existing files in the repository (`PromptTacular/README.md`, `PromptTacular/system_prompt.md`)

## Testing
No automated test suite exists for this documentation-only repository, so validation was performed through content and command verification.
